### PR TITLE
fix: prevent notepad content from leaking into clipboard via text selection

### DIFF
--- a/js/timeline/notepad/notepad.css
+++ b/js/timeline/notepad/notepad.css
@@ -33,6 +33,7 @@
     opacity: 0.55;
     pointer-events: none;
     transform: scale(1) translateX(0);
+    user-select: none;
 }
 
 .ait-notepad-panel.ait-notepad-visible.ait-notepad-focused {


### PR DESCRIPTION
When the notepad loses focus but is not explicitly closed, it sits in the viewport at 55% opacity with pointer-events: none. Because there is no user-select: none, the textarea content is still selectable. Ctrl+A picks up the notepad content along with page content, silently appending it to the clipboard.

I ran into this myself — every time I selected all and copied in Chrome, a fixed block of old notes kept appearing at the end.

Fix: add user-select: none to .ait-notepad-panel.ait-notepad-visible.