### PR TITLE
feat: 支持用户自定义平台适配器，让时间轴扩展到任意 AI 网站

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -195,11 +195,40 @@ const SUPPORTED_DOMAINS = [
     'perplexity.ai', 'claude.ai', 'notebooklm.google.com'
 ];
 
-function isSupportedSite(url) {
+/**
+ * 检查 URL 是否匹配内置支持的平台
+ * @param {string} url - 标签页 URL
+ * @returns {boolean}
+ */
+function isBuiltinSupportedSite(url) {
     try {
         const hostname = new URL(url).hostname;
         return SUPPORTED_DOMAINS.some(d => hostname === d || hostname.endsWith('.' + d));
     } catch { return false; }
+}
+
+/**
+ * 检查 URL 是否匹配用户自定义平台（从 storage 读取）
+ * @param {string} url - 标签页 URL
+ * @returns {Promise<boolean>}
+ */
+async function isCustomSupportedSite(url) {
+    try {
+        const result = await chrome.storage.local.get('customTimelineAdapters');
+        const configs = result.customTimelineAdapters;
+        if (!Array.isArray(configs) || configs.length === 0) return false;
+        return configs.some(cfg => cfg.hostname && url.includes(cfg.hostname));
+    } catch { return false; }
+}
+
+/**
+ * 综合判断当前标签页是否受支持（内置 + 自定义平台）
+ * @param {string} url - 标签页 URL
+ * @returns {Promise<boolean>}
+ */
+async function isSupportedSite(url) {
+    if (isBuiltinSupportedSite(url)) return true;
+    return await isCustomSupportedSite(url);
 }
 
 async function isMirrorSiteBg(url) {
@@ -213,7 +242,7 @@ async function isMirrorSiteBg(url) {
 }
 
 chrome.action.onClicked.addListener(async (tab) => {
-    if (tab.url && isSupportedSite(tab.url)) {
+    if (tab.url && await isSupportedSite(tab.url)) {
         try {
             await chrome.tabs.sendMessage(tab.id, { type: 'OPEN_PANEL_MODAL' });
         } catch {

--- a/js/panelModal/tabs/timeline/index.js
+++ b/js/panelModal/tabs/timeline/index.js
@@ -104,6 +104,16 @@ class TimelineSettingsTab extends BaseTab {
                     </label>
                 </div>
             </div>
+        ${divider}
+            <div class="setting-section">
+                <div class="setting-item">
+                    <div class="setting-info">
+                        <div class="setting-label"><svg class="setting-label-icon" viewBox="0 0 24 24" fill="none" stroke="#6366f1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;"><path d="M12 20h9"/><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z"/></svg>${chrome.i18n.getMessage('customPlatformTitle') || '自定义平台'}</div>
+                        <div class="setting-hint">${chrome.i18n.getMessage('customPlatformHint') || '为其他 AI 网站添加自定义时间轴支持'}</div>
+                    </div>
+                    <button class="starred-manage-btn custom-platform-manage-btn">${chrome.i18n.getMessage('customPlatformManageButton') || '管理'}</button>
+                </div>
+            </div>
         `;
         container.appendChild(scrollArea);
 
@@ -131,6 +141,10 @@ class TimelineSettingsTab extends BaseTab {
 
         this.addEventListener(scrollArea.querySelector('.timeline-theme-color-manage-btn'), 'click', () => {
             this._showThemeColorModal();
+        });
+
+        this.addEventListener(scrollArea.querySelector('.custom-platform-manage-btn'), 'click', () => {
+            this._showCustomPlatformManageModal();
         });
 
         return container;
@@ -432,6 +446,331 @@ class TimelineSettingsTab extends BaseTab {
                 }
             });
         });
+    }
+
+    // ==================== 自定义平台管理 ====================
+
+    /**
+     * 存储 key
+     */
+    _customStorageKey = 'customTimelineAdapters';
+
+    /**
+     * 生成唯一 ID
+     * @returns {string}
+     */
+    _generateId() {
+        return 'custom_' + Date.now().toString(36) + '_' + Math.random().toString(36).substring(2, 8);
+    }
+
+    /**
+     * 打开自定义平台管理弹窗
+     */
+    async _showCustomPlatformManageModal() {
+        const configs = await this._loadCustomConfigs();
+
+        const overlay = document.createElement('div');
+        overlay.className = 'starred-platform-modal-overlay';
+
+        const itemList = configs.length === 0
+            ? `<div class="custom-platform-empty">${chrome.i18n.getMessage('customPlatformEmpty') || '暂无自定义平台，点击下方按钮添加'}</div>`
+            : configs.map(cfg => {
+                const hostnameStr = this._escapeHtml(cfg.hostname || '');
+                const selectorStr = this._escapeHtml(cfg.userMessageSelector || '');
+                return `
+                <div class="custom-platform-item" data-id="${this._escapeHtml(cfg.id)}">
+                    <div class="custom-platform-info">
+                        <div class="custom-platform-name">${this._escapeHtml(cfg.name || cfg.id)}</div>
+                        <div class="custom-platform-detail">
+                            <span class="custom-platform-hostname">🌐 ${hostnameStr}</span>
+                            <span class="custom-platform-selector">🔍 ${selectorStr}</span>
+                        </div>
+                    </div>
+                    <div class="custom-platform-actions">
+                        <button class="custom-platform-edit-btn" data-id="${this._escapeHtml(cfg.id)}" title="${chrome.i18n.getMessage('edit') || '编辑'}">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                        </button>
+                        <button class="custom-platform-delete-btn" data-id="${this._escapeHtml(cfg.id)}" title="${chrome.i18n.getMessage('delete') || '删除'}">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                        </button>
+                    </div>
+                </div>`;
+            }).join('');
+
+        overlay.innerHTML = `
+            <div class="starred-platform-modal custom-platform-modal">
+                <div class="starred-platform-modal-header">
+                    <span>${chrome.i18n.getMessage('customPlatformTitle') || '自定义平台管理'}</span>
+                    <button class="starred-platform-modal-close">✕</button>
+                </div>
+                <div class="starred-platform-modal-body custom-platform-body">
+                    ${itemList}
+                </div>
+                <div class="custom-platform-footer">
+                    <button class="starred-manage-btn custom-platform-add-btn">${chrome.i18n.getMessage('customPlatformAddButton') || '+ 添加新平台'}</button>
+                </div>
+            </div>`;
+
+        document.body.appendChild(overlay);
+
+        const close = () => overlay.remove();
+        overlay.querySelector('.starred-platform-modal-close').addEventListener('click', close);
+        overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+
+        /**
+         * 打开编辑弹窗时，隐藏管理弹窗（避免两个弹窗叠加遮挡）
+         * 编辑弹窗关闭后刷新管理列表
+         */
+        const openEdit = async (cfg) => {
+            overlay.style.display = 'none'; // 先隐藏管理弹窗
+            await this._showCustomPlatformEditModal(cfg);
+            // 编辑弹窗关闭后，销毁管理弹窗并重新打开（刷新列表）
+            close();
+            this._showCustomPlatformManageModal();
+        };
+
+        // 添加按钮
+        overlay.querySelector('.custom-platform-add-btn').addEventListener('click', () => {
+            openEdit(null);
+        });
+
+        // 编辑按钮
+        overlay.querySelectorAll('.custom-platform-edit-btn').forEach(btn => {
+            btn.addEventListener('click', async (e) => {
+                e.stopPropagation();
+                const id = btn.dataset.id;
+                const cfg = configs.find(c => c.id === id);
+                if (cfg) {
+                    openEdit(cfg);
+                }
+            });
+        });
+
+        // 删除按钮
+        overlay.querySelectorAll('.custom-platform-delete-btn').forEach(btn => {
+            btn.addEventListener('click', async (e) => {
+                e.stopPropagation();
+                const id = btn.dataset.id;
+                if (confirm(chrome.i18n.getMessage('customPlatformDeleteConfirm') || '确定要删除这个自定义平台吗？')) {
+                    const updated = configs.filter(c => c.id !== id);
+                    await chrome.storage.local.set({ [this._customStorageKey]: updated });
+                    // 通知 registry 重新加载
+                    close();
+                    this._showCustomPlatformManageModal();
+                }
+            });
+        });
+    }
+
+    /**
+     * 打开自定义平台编辑弹窗（添加/编辑）
+     * 返回 Promise，弹窗关闭后 resolve，确保调用方 await 能正确等待
+     * @param {Object|null} config - 编辑时传入现有配置，新建时传 null
+     * @returns {Promise<void>}
+     */
+    _showCustomPlatformEditModal(config) {
+        return new Promise((resolve) => { this._showCustomPlatformEditModalImpl(config, resolve); });
+    }
+
+    /**
+     * 编辑弹窗实现（内部方法）
+     * @param {Object|null} config
+     * @param {Function} onClose - 弹窗关闭时调用
+     */
+    async _showCustomPlatformEditModalImpl(config, onClose) {
+        const isEdit = !!config;
+        const defaults = {
+            id: '',
+            name: '',
+            hostname: '',
+            turnIdPrefix: '',
+            userMessageSelector: '',
+            textSelector: '',
+            conversationRoute: '',
+            conversationIdRegex: '',
+            timeLabelTargetSelector: '',
+            timeLabelPosition: null,
+            timelinePosition: null,
+            scrollOffset: 30,
+            aiGeneratingSelector: '',
+            aiGeneratingCheck: 'exists',
+            starChatButtonSelector: '',
+            defaultChatThemeSelector: ''
+        };
+
+        const cfg = config ? { ...defaults, ...config } : defaults;
+
+        const overlay = document.createElement('div');
+        overlay.className = 'starred-platform-modal-overlay';
+
+        // 时间标签位置 JSON 字符串
+        const timeLabelPosStr = cfg.timeLabelPosition
+            ? JSON.stringify(cfg.timeLabelPosition)
+            : '';
+        const timelinePosStr = cfg.timelinePosition
+            ? JSON.stringify(cfg.timelinePosition)
+            : '';
+
+        const title = isEdit
+            ? (chrome.i18n.getMessage('customPlatformEditTitle') || '编辑自定义平台')
+            : (chrome.i18n.getMessage('customPlatformAddTitle') || '添加自定义平台');
+
+        overlay.innerHTML = `
+            <div class="starred-platform-modal custom-platform-edit-modal">
+                <div class="starred-platform-modal-header">
+                    <span>${title}</span>
+                    <button class="starred-platform-modal-close">✕</button>
+                </div>
+                <div class="starred-platform-modal-body custom-platform-edit-body">
+                    <div class="custom-platform-form">
+                        <div class="custom-platform-form-section">
+                            <div class="custom-platform-form-section-title">${chrome.i18n.getMessage('customPlatformBasicConfig') || '基本信息'}</div>
+                            <div class="custom-platform-form-group">
+                                <label>${chrome.i18n.getMessage('customPlatformNameLabel') || '平台名称'}</label>
+                                <input type="text" class="custom-platform-input" data-field="name" value="${this._escapeHtml(cfg.name)}" placeholder="${chrome.i18n.getMessage('customPlatformNamePlaceholder') || '例如：我的 AI 助手'}">
+                            </div>
+                            <div class="custom-platform-form-group">
+                                <label>${chrome.i18n.getMessage('customPlatformHostnameLabel') || '域名匹配'}</label>
+                                <input type="text" class="custom-platform-input" data-field="hostname" value="${this._escapeHtml(cfg.hostname)}" placeholder="${chrome.i18n.getMessage('customPlatformHostnamePlaceholder') || '例如：my-ai.example.com'}">
+                                <div class="custom-platform-form-hint">${chrome.i18n.getMessage('customPlatformHostnameHint') || 'URL 包含此字符串即匹配该平台'}</div>
+                            </div>
+                        </div>
+                        <div class="custom-platform-form-section">
+                            <div class="custom-platform-form-section-title">${chrome.i18n.getMessage('customPlatformCoreConfig') || '核心配置（必填）'}</div>
+                            <div class="custom-platform-form-group">
+                                <label>${chrome.i18n.getMessage('customPlatformSelectorLabel') || '用户消息 CSS 选择器'}<span class="required">*</span></label>
+                                <input type="text" class="custom-platform-input" data-field="userMessageSelector" value="${this._escapeHtml(cfg.userMessageSelector)}" placeholder="${chrome.i18n.getMessage('customPlatformSelectorPlaceholder') || '例如：.user-message, [data-role=\"user\"]'}">
+                            </div>
+                            <div class="custom-platform-form-group">
+                                <label>${chrome.i18n.getMessage('customPlatformTextSelectorLabel') || '文本提取子选择器（可选）'}</label>
+                                <input type="text" class="custom-platform-input" data-field="textSelector" value="${this._escapeHtml(cfg.textSelector)}" placeholder="${chrome.i18n.getMessage('customPlatformTextSelectorPlaceholder') || '例如：.message-content, 留空则提取全部文本'}">
+                            </div>
+                            <div class="custom-platform-form-group">
+                                <label>${chrome.i18n.getMessage('customPlatformRouteLabel') || '对话路由匹配'}<span class="required">*</span></label>
+                                <input type="text" class="custom-platform-input" data-field="conversationRoute" value="${this._escapeHtml(cfg.conversationRoute)}" placeholder="${chrome.i18n.getMessage('customPlatformRoutePlaceholder') || '例如：/chat/'}">
+                                <div class="custom-platform-form-hint">${chrome.i18n.getMessage('customPlatformRouteHint') || 'URL pathname 包含此字符串时为对话页面'}</div>
+                            </div>
+                            <div class="custom-platform-form-group">
+                                <label>${chrome.i18n.getMessage('customPlatformIdRegexLabel') || '会话 ID 提取正则（可选）'}</label>
+                                <input type="text" class="custom-platform-input" data-field="conversationIdRegex" value="${this._escapeHtml(cfg.conversationIdRegex)}" placeholder="${chrome.i18n.getMessage('customPlatformIdRegexPlaceholder') || '例如：/chat/([^/]+)，留空则以完整 URL 作为存储键'}">
+                                <div class="custom-platform-form-hint">${chrome.i18n.getMessage('customPlatformIdRegexHint') || '用括号捕获会话 ID，如 /chat/(xxx) 中捕获 xxx'}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="custom-platform-footer">
+                    <button class="starred-manage-btn custom-platform-save-btn">${chrome.i18n.getMessage('save') || '保存'}</button>
+                    <button class="starred-manage-btn custom-platform-cancel-btn" style="background:transparent;color:var(--ait-text-secondary);border:1px solid var(--ait-border-color);">${chrome.i18n.getMessage('cancel') || '取消'}</button>
+                </div>
+            </div>`;
+
+        document.body.appendChild(overlay);
+
+        // 关闭时同时触发 onClose 回调，让 Promise resolve，管理弹窗才能正确等待
+        // 用 mousedown 而非 click 标记拖拽起点，防止在弹窗内选择文字后鼠标拖出导致误关闭
+        let mouseDownInsideModal = false;
+        const modal = overlay.querySelector('.starred-platform-modal');
+        overlay.addEventListener('mousedown', (e) => {
+            mouseDownInsideModal = modal.contains(e.target);
+        });
+        const close = () => { overlay.remove(); onClose?.(); };
+        overlay.querySelector('.starred-platform-modal-close').addEventListener('click', close);
+        overlay.querySelector('.custom-platform-cancel-btn').addEventListener('click', close);
+        overlay.addEventListener('click', (e) => {
+            // 只有 mousedown 也在弹窗外时才关闭（防止拖拽选字后鼠标松开在遮罩上触发关闭）
+            if (e.target === overlay && !mouseDownInsideModal) close();
+        });
+
+        // 保存按钮
+        overlay.querySelector('.custom-platform-save-btn').addEventListener('click', async () => {
+            const newCfg = {
+                id: cfg.id || this._generateId(),
+                name: overlay.querySelector('[data-field="name"]')?.value?.trim() || '',
+                hostname: overlay.querySelector('[data-field="hostname"]')?.value?.trim() || '',
+                turnIdPrefix: overlay.querySelector('[data-field="turnIdPrefix"]')?.value?.trim() || '',
+                userMessageSelector: overlay.querySelector('[data-field="userMessageSelector"]')?.value?.trim() || '',
+                textSelector: overlay.querySelector('[data-field="textSelector"]')?.value?.trim() || '',
+                conversationRoute: overlay.querySelector('[data-field="conversationRoute"]')?.value?.trim() || '',
+                conversationIdRegex: overlay.querySelector('[data-field="conversationIdRegex"]')?.value?.trim() || '',
+                timeLabelTargetSelector: overlay.querySelector('[data-field="timeLabelTargetSelector"]')?.value?.trim() || '',
+                scrollOffset: parseInt(overlay.querySelector('[data-field="scrollOffset"]')?.value) || 30,
+                aiGeneratingSelector: overlay.querySelector('[data-field="aiGeneratingSelector"]')?.value?.trim() || '',
+                aiGeneratingCheck: overlay.querySelector('[data-field="aiGeneratingCheck"]')?.value || 'exists',
+                starChatButtonSelector: overlay.querySelector('[data-field="starChatButtonSelector"]')?.value?.trim() || '',
+                defaultChatThemeSelector: overlay.querySelector('[data-field="defaultChatThemeSelector"]')?.value?.trim() || ''
+            };
+
+            // 验证必填字段
+            if (!newCfg.name) {
+                alert(chrome.i18n.getMessage('customPlatformNameRequired') || '请输入平台名称');
+                return;
+            }
+            if (!newCfg.hostname) {
+                alert(chrome.i18n.getMessage('customPlatformHostnameRequired') || '请输入域名匹配');
+                return;
+            }
+            if (!newCfg.userMessageSelector) {
+                alert(chrome.i18n.getMessage('customPlatformSelectorRequired') || '请输入用户消息 CSS 选择器');
+                return;
+            }
+            if (!newCfg.conversationRoute) {
+                alert(chrome.i18n.getMessage('customPlatformRouteRequired') || '请输入对话路由匹配');
+                return;
+            }
+            // 解析 JSON 字段
+            try {
+                const timeLabelPosRaw = overlay.querySelector('[data-field="timeLabelPosition"]')?.value?.trim();
+                if (timeLabelPosRaw) {
+                    newCfg.timeLabelPosition = JSON.parse(timeLabelPosRaw);
+                }
+            } catch (e) { /* 解析失败则忽略 */ }
+
+            try {
+                const timelinePosRaw = overlay.querySelector('[data-field="timelinePosition"]')?.value?.trim();
+                if (timelinePosRaw) {
+                    newCfg.timelinePosition = JSON.parse(timelinePosRaw);
+                }
+            } catch (e) { /* 解析失败则忽略 */ }
+
+            // 保存到 storage
+            const configs = await this._loadCustomConfigs();
+            if (isEdit) {
+                const idx = configs.findIndex(c => c.id === cfg.id);
+                if (idx >= 0) {
+                    configs[idx] = newCfg;
+                }
+            } else {
+                configs.push(newCfg);
+            }
+            await chrome.storage.local.set({ [this._customStorageKey]: configs });
+
+            close();
+        });
+    }
+
+    /**
+     * 从 storage 加载自定义平台配置
+     * @returns {Promise<Array>}
+     */
+    async _loadCustomConfigs() {
+        try {
+            const result = await chrome.storage.local.get(this._customStorageKey);
+            return Array.isArray(result[this._customStorageKey]) ? result[this._customStorageKey] : [];
+        } catch (e) {
+            return [];
+        }
+    }
+
+    /**
+     * HTML 转义
+     * @param {string} str
+     * @returns {string}
+     */
+    _escapeHtml(str) {
+        if (!str) return '';
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
     }
 
     unmounted() {

--- a/js/panelModal/tabs/timeline/styles.css
+++ b/js/panelModal/tabs/timeline/styles.css
@@ -366,3 +366,278 @@ html[data-timeline-theme="dark"] .timeline-active-color-btn.selected {
 html[data-timeline-theme="dark"] .timeline-active-color-btn.selected::before {
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.24), 0 1px 2px rgba(0, 0, 0, 0.35);
 }
+
+/* ==================== 自定义平台管理样式 ==================== */
+
+/* 自定义平台编辑图标 */
+.setting-label-icon svg {
+    vertical-align: middle;
+}
+
+/* 自定义平台管理弹窗 */
+.custom-platform-modal {
+    max-width: 520px;
+}
+
+.custom-platform-body {
+    max-height: 360px;
+    overflow-y: auto;
+    padding: 12px 16px;
+}
+
+/* 空状态 */
+.custom-platform-empty {
+    text-align: center;
+    color: #9ca3af;
+    font-size: 13px;
+    padding: 32px 16px;
+}
+
+/* 自定义平台项 */
+.custom-platform-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px;
+    background: #f9fafb;
+    border-radius: 8px;
+    margin-bottom: 8px;
+    transition: background 0.2s;
+}
+
+.custom-platform-item:last-child {
+    margin-bottom: 0;
+}
+
+.custom-platform-item:hover {
+    background: #f3f4f6;
+}
+
+.custom-platform-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.custom-platform-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 4px;
+}
+
+.custom-platform-detail {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-size: 12px;
+    color: #6b7280;
+}
+
+.custom-platform-hostname,
+.custom-platform-selector {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    white-space: nowrap;
+}
+
+/* 操作按钮 */
+.custom-platform-actions {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+    margin-left: 12px;
+}
+
+.custom-platform-edit-btn,
+.custom-platform-delete-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border: none;
+    background: transparent;
+    border-radius: 6px;
+    cursor: pointer;
+    color: #6b7280;
+    transition: all 0.2s;
+}
+
+.custom-platform-edit-btn:hover {
+    background: #e5e7eb;
+    color: #6366f1;
+}
+
+.custom-platform-delete-btn:hover {
+    background: #fee2e2;
+    color: #ef4444;
+}
+
+/* 底部按钮区 */
+.custom-platform-footer {
+    padding: 12px 16px;
+    border-top: 1px solid #e5e7eb;
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.custom-platform-add-btn {
+    width: 100%;
+    justify-content: center;
+}
+
+/* 编辑表单 */
+.custom-platform-edit-modal {
+    max-width: 620px;
+    width: 90vw;
+}
+
+.custom-platform-edit-body {
+    max-height: 460px;
+    overflow-y: auto;
+    padding: 16px;
+}
+
+.custom-platform-form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.custom-platform-form-section {
+    background: #f9fafb;
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.custom-platform-form-section-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #6366f1;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    user-select: none;
+}
+
+.custom-platform-toggle-icon {
+    font-size: 10px;
+    color: #9ca3af;
+}
+
+.custom-platform-form-group {
+    margin-bottom: 12px;
+}
+
+.custom-platform-form-group:last-child {
+    margin-bottom: 0;
+}
+
+.custom-platform-form-group label {
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    color: #374151;
+    margin-bottom: 4px;
+}
+
+.custom-platform-form-group label .required {
+    color: #ef4444;
+    margin-left: 2px;
+}
+
+.custom-platform-input {
+    width: 100%;
+    padding: 8px 10px;
+    font-size: 13px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #1f2937;
+    outline: none;
+    box-sizing: border-box;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.custom-platform-input:focus {
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
+.custom-platform-input::placeholder {
+    color: #9ca3af;
+}
+
+select.custom-platform-input {
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%236b7280' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    padding-right: 28px;
+}
+
+.custom-platform-form-hint {
+    font-size: 11px;
+    color: #9ca3af;
+    margin-top: 4px;
+}
+
+/* 展开/收起的高级配置区域 */
+.custom-platform-advanced-content {
+    padding-top: 4px;
+}
+
+/* 暗色主题适配 */
+html[data-timeline-theme="dark"] .custom-platform-item {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+html[data-timeline-theme="dark"] .custom-platform-item:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+html[data-timeline-theme="dark"] .custom-platform-name {
+    color: #e5e7eb;
+}
+
+html[data-timeline-theme="dark"] .custom-platform-edit-btn:hover {
+    background: rgba(99, 102, 241, 0.15);
+}
+
+html[data-timeline-theme="dark"] .custom-platform-delete-btn:hover {
+    background: rgba(239, 68, 68, 0.15);
+}
+
+html[data-timeline-theme="dark"] .custom-platform-form-section {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+html[data-timeline-theme="dark"] .custom-platform-form-group label {
+    color: #d1d5db;
+}
+
+html[data-timeline-theme="dark"] .custom-platform-input {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.1);
+    color: #e5e7eb;
+}
+
+html[data-timeline-theme="dark"] .custom-platform-input:focus {
+    border-color: #818cf8;
+    box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.15);
+}
+
+html[data-timeline-theme="dark"] .custom-platform-input::placeholder {
+    color: #6b7280;
+}
+
+html[data-timeline-theme="dark"] .custom-platform-empty {
+    color: #6b7280;
+}
+
+html[data-timeline-theme="dark"] .custom-platform-footer {
+    border-top-color: rgba(255, 255, 255, 0.08);
+}

--- a/js/timeline/adapters/custom.js
+++ b/js/timeline/adapters/custom.js
@@ -1,0 +1,243 @@
+/**
+ * Custom Site Adapter - 用户自定义平台适配器
+ * 
+ * 允许用户通过设置面板自定义配置，支持任意 AI 聊天网站的时间轴功能。
+ * 所有配置参数来自用户在设置面板中的输入，持久化存储在 chrome.storage.local。
+ * 
+ * 配置结构 (CustomPlatformConfig):
+ * {
+ *   id: string,              // 唯一标识（自动生成）
+ *   name: string,            // 平台显示名称
+ *   hostname: string,        // 域名匹配关键字（include 匹配）
+ *   turnIdPrefix: string,    // turnId 前缀，默认用 id
+ *   userMessageSelector: string,     // 用户消息 CSS 选择器（必填）
+ *   textSelector: string,            // 文本提取子选择器（可选）
+ *   conversationRoute: string,       // 对话页面路由匹配（include 匹配，必填）
+ *   conversationIdRegex: string,     // 会话 ID 提取正则（必填）
+ *   timeLabelTargetSelector: string, // 时间标签渲染目标子选择器（可选）
+ *   timeLabelPosition: Object,       // 时间标签 CSS 位置（可选）
+ *   timelinePosition: Object,        // 时间轴浮窗位置（可选）
+ *   scrollOffset: number,            // 滚动偏移量（可选）
+ *   aiGeneratingSelector: string,    // AI 生成中检测选择器（可选）
+ *   aiGeneratingCheck: string,       // AI 检测方式: 'exists' | 'class' | 'attr', 默认 'exists'（可选）
+ *   starChatButtonSelector: string,  // 收藏按钮目标选择器（可选）
+ *   defaultChatThemeSelector: string,// 默认标题提取选择器（可选）
+ * }
+ */
+
+class CustomSiteAdapter extends SiteAdapter {
+    /**
+     * @param {Object} config - 用户自定义的平台配置
+     */
+    constructor(config) {
+        super();
+        this.config = config;
+        this.id = config.id;
+        this.name = config.name;
+    }
+
+    // ==================== 核心方法（必须实现） ====================
+
+    /**
+     * 检查当前 URL 是否匹配此平台
+     * 使用 config.hostname 进行 include 匹配
+     * @param {string} url - 当前页面 URL
+     * @returns {boolean}
+     */
+    matches(url) {
+        return url.includes(this.config.hostname);
+    }
+
+    /**
+     * 获取用户消息元素的 CSS 选择器
+     * @returns {string}
+     */
+    getUserMessageSelector() {
+        return this.config.userMessageSelector;
+    }
+
+    /**
+     * 生成节点的唯一标识 turnId
+     * 使用 config.turnIdPrefix 作为前缀，加上数组索引
+     * @param {Element} element - 消息 DOM 元素
+     * @param {number} index - 消息索引
+     * @returns {string}
+     */
+    generateTurnId(element, index) {
+        const prefix = this.config.turnIdPrefix || this.config.id || 'custom';
+        return `${prefix}-${index}`;
+    }
+
+    /**
+     * 提取消息元素的文本内容
+     * 如果配置了 textSelector，则优先查找子元素提取文本
+     * @param {Element} element - 消息 DOM 元素
+     * @returns {string}
+     */
+    extractText(element) {
+        if (this.config.textSelector) {
+            const target = element.querySelector(this.config.textSelector);
+            if (target) {
+                const text = target.textContent.replace(/\s+/g, ' ').trim();
+                return text || '[图片或文件]';
+            }
+        }
+        // 回退：直接提取整个元素的文本
+        const text = (element.textContent || '').replace(/\s+/g, ' ').trim();
+        return text || '[图片或文件]';
+    }
+
+    /**
+     * 检查当前路径是否为对话页面
+     * @param {string} pathname - URL pathname
+     * @returns {boolean}
+     */
+    isConversationRoute(pathname) {
+        if (!this.config.conversationRoute) return false;
+        return pathname.includes(this.config.conversationRoute);
+    }
+
+    /**
+     * 从 pathname 中提取会话 ID
+     * 使用 config.conversationIdRegex 正则提取
+     * @param {string} pathname - URL pathname
+     * @returns {string|null}
+     */
+    extractConversationId(pathname) {
+        if (!this.config.conversationIdRegex) return null;
+        try {
+            const regex = new RegExp(this.config.conversationIdRegex);
+            const match = pathname.match(regex);
+            return match ? (match[1] || match[0]) : null;
+        } catch (e) {
+            console.error('[CustomSiteAdapter] Invalid regex:', this.config.conversationIdRegex, e);
+            return null;
+        }
+    }
+
+    // ==================== 可选方法 ====================
+
+    /**
+     * 获取时间标签的渲染目标元素
+     * @param {Element} element - 用户消息元素
+     * @returns {Element}
+     */
+    getTimeLabelTarget(element) {
+        if (this.config.timeLabelTargetSelector) {
+            const target = element.querySelector(this.config.timeLabelTargetSelector);
+            if (target) return target;
+        }
+        return super.getTimeLabelTarget(element);
+    }
+
+    /**
+     * 获取时间标签位置配置
+     * @returns {Object} - { top, right, left, bottom }
+     */
+    getTimeLabelPosition() {
+        if (this.config.timeLabelPosition) {
+            return this.config.timeLabelPosition;
+        }
+        return super.getTimeLabelPosition();
+    }
+
+    /**
+     * 获取时间轴浮窗位置配置
+     * @returns {Object}
+     */
+    getTimelinePosition() {
+        if (this.config.timelinePosition) {
+            return this.config.timelinePosition;
+        }
+        return super.getTimelinePosition();
+    }
+
+    /**
+     * 查找对话容器元素
+     * 使用 LCA（最近共同祖先）算法
+     * @param {Element} firstMessage - 第一条消息元素
+     * @returns {Element|null}
+     */
+    findConversationContainer(firstMessage) {
+        return ContainerFinder.findConversationContainer(firstMessage, {
+            messageSelector: this.getUserMessageSelector()
+        });
+    }
+
+    /**
+     * 获取收藏按钮的插入目标元素
+     * @returns {Element|null}
+     */
+    getStarChatButtonTarget() {
+        if (this.config.starChatButtonSelector) {
+            return document.querySelector(this.config.starChatButtonSelector);
+        }
+        return super.getStarChatButtonTarget();
+    }
+
+    /**
+     * 获取默认对话主题（标题）
+     * @returns {string}
+     */
+    getDefaultChatTheme() {
+        if (this.config.defaultChatThemeSelector === 'title') {
+            return document.title || '';
+        }
+        if (this.config.defaultChatThemeSelector) {
+            const el = document.querySelector(this.config.defaultChatThemeSelector);
+            return (el?.textContent || '').trim();
+        }
+        return super.getDefaultChatTheme();
+    }
+
+    /**
+     * 获取滚动偏移量
+     * @returns {number}
+     */
+    getScrollOffset() {
+        if (this.config.scrollOffset !== undefined) {
+            return this.config.scrollOffset;
+        }
+        return super.getScrollOffset();
+    }
+
+    /**
+     * 检测 AI 是否正在生成回答
+     * 支持三种检测方式：
+     * - 'exists': 检查选择器元素是否存在
+     * - 'class': 检查选择器元素是否包含 'stop' class
+     * - 'attr': 检查选择器元素是否有特定属性
+     * @returns {boolean|null} - true: 正在生成, false: 未生成, null: 未配置
+     */
+    isAIGenerating() {
+        if (!this.config.aiGeneratingSelector) return null;
+
+        const element = document.querySelector(this.config.aiGeneratingSelector);
+        if (!element) return false;
+
+        const checkType = this.config.aiGeneratingCheck || 'exists';
+
+        switch (checkType) {
+            case 'exists':
+                return true;
+            case 'class':
+                return element.classList.contains('stop');
+            case 'attr': {
+                // 检查 data-testid="stop-button" 这种
+                const attrName = this.config.aiGeneratingAttrName || 'data-testid';
+                const attrValue = this.config.aiGeneratingAttrValue || 'stop-button';
+                return element.getAttribute(attrName) === attrValue;
+            }
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * 检测是否应该隐藏时间轴
+     * @returns {boolean}
+     */
+    shouldHideTimeline() {
+        return false; // 自定义平台默认不隐藏
+    }
+}

--- a/js/timeline/adapters/registry.js
+++ b/js/timeline/adapters/registry.js
@@ -1,12 +1,20 @@
 /**
  * Adapter Registry
  * 
- * Manages all site adapters and provides auto-detection
+ * Manages all site adapters and provides auto-detection.
+ * 
+ * Supports:
+ * - 内置适配器（hard-coded built-in adapters）
+ * - 用户自定义适配器（从 chrome.storage.local 动态加载）
+ * 
+ * 自定义适配器优先级高于内置适配器：
+ * 如果用户为某个已支持的平台创建了自定义配置，自定义版本将覆盖内置版本。
  */
 
 class SiteAdapterRegistry {
     constructor() {
-        this.adapters = [
+        /** @type {SiteAdapter[]} 内置适配器列表 */
+        this._builtinAdapters = [
             new ChatGPTAdapter(),
             new GeminiAdapter(),
             new DoubaoAdapter(),
@@ -20,12 +28,103 @@ class SiteAdapterRegistry {
             new PerplexityAdapter(),
             new ClaudeAdapter(),
             new NotebookLMAdapter(),
-            // Add more adapters here in the future
         ];
+
+        /** @type {CustomSiteAdapter[]} 用户自定义适配器列表 */
+        this._customAdapters = [];
+
+        /** @type {boolean} 自定义适配器是否已加载 */
+        this._customLoaded = false;
     }
 
     /**
-     * Detect and return the appropriate adapter for current site
+     * 获取所有适配器（自定义优先，内置其次）
+     * 自定义适配器排前面，这样同域名下自定义覆盖内置
+     * @returns {SiteAdapter[]}
+     */
+    get adapters() {
+        return [...this._customAdapters, ...this._builtinAdapters];
+    }
+
+    /**
+     * 从 chrome.storage.local 加载用户自定义适配器
+     * 异步方法，应在页面初始化早期调用
+     * @returns {Promise<void>}
+     */
+    async loadCustomAdapters() {
+        if (this._customLoaded) return;
+
+        try {
+            const result = await chrome.storage.local.get('customTimelineAdapters');
+            const configs = result.customTimelineAdapters || [];
+
+            if (!Array.isArray(configs)) {
+                console.warn('[SiteAdapterRegistry] Invalid customTimelineAdapters data, resetting');
+                this._customAdapters = [];
+                this._customLoaded = true;
+                return;
+            }
+
+            // 过滤掉无效配置，构建 CustomSiteAdapter 实例
+            this._customAdapters = configs
+                .filter(cfg => this._validateConfig(cfg))
+                .map(cfg => new CustomSiteAdapter(cfg));
+
+            this._customLoaded = true;
+
+            if (this._customAdapters.length > 0) {
+                console.log(`[SiteAdapterRegistry] Loaded ${this._customAdapters.length} custom adapters:`,
+                    this._customAdapters.map(a => a.name));
+            }
+        } catch (e) {
+            console.error('[SiteAdapterRegistry] Failed to load custom adapters:', e);
+            this._customAdapters = [];
+            this._customLoaded = true;
+        }
+    }
+
+    /**
+     * 重新加载自定义适配器（配置变更后调用）
+     * @returns {Promise<void>}
+     */
+    async reloadCustomAdapters() {
+        this._customLoaded = false;
+        this._customAdapters = [];
+        await this.loadCustomAdapters();
+    }
+
+    /**
+     * 验证自定义适配器配置是否有效
+     * @param {Object} config - 用户配置
+     * @returns {boolean}
+     */
+    _validateConfig(config) {
+        if (!config || typeof config !== 'object') return false;
+        // 必填字段检查
+        if (!config.id) {
+            console.warn('[SiteAdapterRegistry] Custom adapter missing "id", skipping');
+            return false;
+        }
+        if (!config.hostname) {
+            console.warn('[SiteAdapterRegistry] Custom adapter missing "hostname", skipping:', config.id);
+            return false;
+        }
+        if (!config.userMessageSelector) {
+            console.warn('[SiteAdapterRegistry] Custom adapter missing "userMessageSelector", skipping:', config.id);
+            return false;
+        }
+        if (!config.conversationRoute) {
+            console.warn('[SiteAdapterRegistry] Custom adapter missing "conversationRoute", skipping:', config.id);
+            return false;
+        }
+        // conversationIdRegex 为可选字段，留空时 extractConversationId 返回 null，
+        // 系统自动以完整 URL 作为存储 key，不影响时间轴核心功能
+        return true;
+    }
+
+    /**
+     * 检测并返回当前网站对应的适配器
+     * 自定义适配器优先（排在前面），匹配到即返回
      * @returns {SiteAdapter|null}
      */
     detectAdapter() {
@@ -39,11 +138,19 @@ class SiteAdapterRegistry {
     }
 
     /**
-     * Check if current site is supported
+     * 检查当前网站是否被支持
      * @returns {boolean}
      */
     isSupportedSite() {
         return this.detectAdapter() !== null;
     }
-}
 
+    /**
+     * 获取当前适配器是否为自定义适配器
+     * @param {SiteAdapter} adapter - 适配器实例
+     * @returns {boolean}
+     */
+    isCustomAdapter(adapter) {
+        return adapter instanceof CustomSiteAdapter;
+    }
+}

--- a/js/timeline/index.js
+++ b/js/timeline/index.js
@@ -36,7 +36,8 @@ function sleep(ms) {
 async function isPlatformEnabled() {
     try {
         const platform = getCurrentPlatform();
-        if (!platform) return true; // 未知平台，默认启用
+        // 未知平台（包括自定义平台）：默认启用
+        if (!platform) return true;
         
         // ✅ 首先检查平台是否支持时间轴功能
         if (platform.features?.timeline !== true) {
@@ -66,14 +67,17 @@ function canInitialize() {
 }
 
 // Initialize timeline with retry mechanism (exponential backoff)
+// 首次立即尝试，失败再走重试延迟列表，减少切换会话时的可感知延迟
 async function initWithRetry(version, delays, retryIndex = 0) {
     // Check if we've exceeded max retries
     if (retryIndex >= delays.length) {
         return;
     }
     
-    // Wait for the specified delay
-    await sleep(delays[retryIndex]);
+    // 首次（retryIndex === 0）不等待，立即检测；后续重试才 sleep
+    if (retryIndex > 0) {
+        await sleep(delays[retryIndex - 1]);
+    }
     
     // Check if version is still current (user may have navigated away)
     if (version !== initVersion) {
@@ -148,6 +152,9 @@ function initializeTimeline() {
     // 2. 清理原生收藏按钮（正常文档流中的收藏按钮）
     TimelineUtils.removeElementSafe(document.querySelector('.ait-timeline-star-chat-btn-native'));
     
+    // 3. 全局清理残留的 scroll-padding 元素，防止 flex 布局抖动
+    document.querySelectorAll('.ait-scroll-padding').forEach(el => el.remove());
+    
     try {
         timelineManagerInstance = new TimelineManager(currentAdapter);
         timelineManagerInstance.init().catch(err => {});
@@ -177,6 +184,10 @@ async function handleUrlChange() {
         try { timelineManagerInstance.destroy(); } catch {}
         timelineManagerInstance = null;
     }
+    
+    // 提前清理所有可能残留的 ait-scroll-padding 元素，防止 flex 布局抖动
+    // destroy() 只清理已知 container 中的 padding，这里做全局兜底扫描
+    document.querySelectorAll('.ait-scroll-padding').forEach(el => el.remove());
     
     // 停止 AI 状态监控（initializeTimeline 中会重新启动）
     if (window.AIStateMonitor) {
@@ -246,16 +257,40 @@ function setupPlatformSettingsListener() {
                 }
             }
         }
+        
+        // ✅ 监听自定义适配器配置变化
+        if (changes.customTimelineAdapters) {
+            console.log('[Timeline] Custom adapters changed, reloading...');
+            adapterRegistry.reloadCustomAdapters().then(() => {
+                // 重新检测适配器，如果需要则重新初始化
+                if (isConversationRoute()) {
+                    const newAdapter = adapterRegistry.detectAdapter();
+                    if (newAdapter && newAdapter !== currentAdapter) {
+                        currentAdapter = newAdapter;
+                        initVersion++;
+                        const currentVersion = initVersion;
+                        initWithRetry(currentVersion, TIMELINE_CONFIG.INIT_RETRY_DELAYS);
+                    }
+                }
+            });
+        }
     });
 }
 
-// Check if current site is supported before initializing
-if (!adapterRegistry.isSupportedSite()) {
-} else {
-    currentAdapter = adapterRegistry.detectAdapter();
+// ✅ 设置平台设置监听器（监听用户在设置中切换平台开关）
+setupPlatformSettingsListener();
+
+// 主初始化流程：先加载自定义适配器，再检测平台
+async function mainInit() {
+    // ✅ 加载用户自定义适配器（优先于内置适配器检测）
+    await adapterRegistry.loadCustomAdapters();
     
-    // ✅ 设置平台设置监听器（监听用户在设置中切换平台开关）
-    setupPlatformSettingsListener();
+    // 检查是否被支持（内置 + 自定义）
+    if (!adapterRegistry.isSupportedSite()) {
+        return;
+    }
+    
+    currentAdapter = adapterRegistry.detectAdapter();
     
     // ✅ 修复：先检查DOM中是否已存在用户消息（SPA路由切换场景）
     const checkAndInit = () => {
@@ -305,3 +340,5 @@ if (!adapterRegistry.isSupportedSite()) {
         }
     })();
 }
+
+mainInit()

--- a/js/timeline/timeline-manager.js
+++ b/js/timeline/timeline-manager.js
@@ -2964,7 +2964,7 @@ class TimelineManager {
         if (!paddingEl) {
             paddingEl = document.createElement('div');
             paddingEl.className = 'ait-scroll-padding';
-            paddingEl.style.cssText = 'pointer-events: none; width: 100%; flex-shrink: 0; order: 9999; height: 0; transition: height 0.3s ease-out;';
+            paddingEl.style.cssText = 'pointer-events: none; width: 100%; min-width: 0; flex-shrink: 0; order: 9999; height: 0; transition: height 0.3s ease-out; overflow: hidden;';
             this._currentPadding = 0;
         }
         

--- a/manifest.json
+++ b/manifest.json
@@ -153,6 +153,7 @@
         "js/timeline/adapters/perplexity.js",
         "js/timeline/adapters/claude.js",
         "js/timeline/adapters/notebooklm.js",
+        "js/timeline/adapters/custom.js",
         "js/timeline/adapters/registry.js",
         "js/mermaid/lib/mermaid.min.js",
         "js/mermaid/index.js",


### PR DESCRIPTION
## 功能简介

本 PR 新增了「自定义平台」功能，允许用户在插件设置面板中通过可视化表单，为任意 AI 对话网站配置时间轴适配器，无需修改代码。

## 解决的问题

目前插件只支持固定的 14 个内置平台。当用户使用其他 AI 对话网站（如公司内部 AI、小众 AI 产品等）时，无法享受时间轴功能，体验割裂。

## 实现方案

### 架构设计

新增 `CustomSiteAdapter` 类，继承自 `SiteAdapter` 基类，所有行为由用户配置驱动：

```
用户填写表单 → 存入 chrome.storage.local → CustomSiteAdapter 实例化 → 注入时间轴
```

自定义适配器优先级高于内置适配器，支持与内置平台共存。

### 配置项说明

**必填：**
- 平台名称
- 域名匹配（URL 包含此字符串即匹配）
- 用户消息 CSS 选择器
- 对话路由匹配（pathname 包含此字符串时为对话页面）

**可选：**
- 文本提取子选择器（留空则提取整个消息元素文本）
- 会话 ID 提取正则（留空则以完整 URL 作为存储 key）

### 变更文件

| 文件 | 变更内容 |
|------|---------|
| `js/timeline/adapters/custom.js` | 新增 `CustomSiteAdapter` 类 |
| `js/timeline/adapters/registry.js` | 支持异步加载/重载自定义适配器 |
| `js/timeline/index.js` | 异步初始化流程；立即重试减少切换会话延迟；URL 变化时全局清理 scroll-padding |
| `js/timeline/timeline-manager.js` | scroll-padding 增加 flex 布局防护，防止切换会话时布局抖动 |
| `js/background.js` | icon 点击判断逻辑支持自定义平台域名 |
| `js/panelModal/tabs/timeline/index.js` | 自定义平台管理 UI（列表、添加、编辑、删除） |
| `js/panelModal/tabs/timeline/styles.css` | 自定义平台 UI 样式，含暗色主题适配 |
| `manifest.json` | 注册 `adapters/custom.js` 为 content script |

## 使用方式

1. 打开插件设置面板 → **Timeline 设置** Tab
2. 滚动到底部「**自定义平台**」→ 点击「**管理**」
3. 点击「**+ 添加新平台**」，填写域名和 CSS 选择器
4. 保存后打开对应网站的对话页面，时间轴即可生效

## 其他改进

- 修复切换会话时 `.ait-scroll-padding` 残留导致的 flex 布局抖动问题
- 优化时间轴初始化策略：切换会话后立即尝试检测 DOM，而非固定等待 500ms，减少可感知延迟
