### PR TITLE
fix: normalize copied LaTeX newlines

### DIFF
--- a/js/formula/formula-manager.js
+++ b/js/formula/formula-manager.js
@@ -25,6 +25,28 @@ function applyFormulaFormat(formula, formatId) {
     return template.replace('%s', formula);
 }
 
+function normalizeLatexForCopy(latex) {
+  if (!latex || typeof latex !== 'string') return latex;
+
+  let s = latex
+    .replace(/\u00a0/g, ' ')
+    .replace(/\r\n?/g, '\n')
+    .trim();
+
+  if (!s.includes('\n')) return s;
+
+  // 文本类命令里，换行替换为空格，避免单词粘连
+  if (/\\(?:text|mbox|mathrm|operatorname)\s*\{/.test(s)) {
+    return s
+      .replace(/[ \t]*\n+[ \t]*/g, ' ')
+      .replace(/[ \t]{2,}/g, ' ')
+      .trim();
+  }
+
+  // 普通数学公式里，换行通常只是 KaTeX/ChatGPT 输出的排版噪音
+  return s.replace(/[ \t]*\n+[ \t]*/g, '');
+}
+
 // ==================== FormulaManager 类 ====================
 
 class FormulaManager {
@@ -365,7 +387,8 @@ class FormulaManager {
             }
             const result = await chrome.storage.local.get('formulaFormat');
             const formatId = result.formulaFormat || 'none';
-            const formatted = applyFormulaFormat(latexCode, formatId);
+            const normalizedLatex = normalizeLatexForCopy(latexCode);
+            const formatted = applyFormulaFormat(normalizedLatex, formatId);
             await navigator.clipboard.writeText(formatted);
             this.showCopyFeedback(TimelineI18n.getMessage('xpzmvk'), formulaElement, false);
         } catch (err) {


### PR DESCRIPTION
Fixes #110

## What changed

This PR normalizes LaTeX before copying it to the clipboard.

ChatGPT/KaTeX may expose LaTeX source in `annotation[encoding="application/x-tex"]` with line breaks, which caused copied LaTeX to be pasted as multiple lines, for example:

```latex
\sigma_R
=
\frac{c}{2}\sigma_\tau
```

After this change, regular math LaTeX is copied as:

```latex
\sigma_R=\frac{c}{2}\sigma_\tau
```

For text-like commands such as \text{...}, line breaks are converted to spaces to avoid joining words unexpectedly.

## Testing
- Loaded the extension locally as an unpacked extension.
- Refreshed ChatGPT.
- Copied a rendered formula as LaTeX.
- Verified the copied result is single-line LaTeX.